### PR TITLE
Enable negative cost input

### DIFF
--- a/script.js
+++ b/script.js
@@ -200,7 +200,8 @@ function calculateResults() {
   // Pobierz dane wejściowe
   const savings = parseFloat(document.getElementById('savingsAmount').value);
   const taxRate = parseFloat(document.getElementById('taxRate').value);
-  const positionCost = parseFloat(document.getElementById('positionCost').value); // New field
+  let positionCost = parseFloat(document.getElementById('positionCost').value);
+  if (isNaN(positionCost)) positionCost = 0; // allow temporarily blank/"-" input
   const lockPeriod = parseFloat(document.getElementById('lockPeriod').value);
   const compound = document.getElementById('useCompoundInterest').checked;
 


### PR DESCRIPTION
## Summary
- handle temporary blank or negative input for position cost when calculating

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686b967013f083218f8a1ce2e1ea848f