### PR TITLE
Handle bad inputs in calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,14 +40,15 @@
 <!-- Main Input Fields -->
 <div id="simulationSection" class="card mb-4">
   <div class="card-body">
-    <form id="simulationForm">
+      <form id="simulationForm">
+        <div id="inputError" class="alert alert-danger d-none" role="alert"></div>
       <div class="mb-4 row">
         <label for="savingsAmount" class="col-sm-4 col-form-label" data-i18n="savingsLabel">
           <i class="fas fa-wallet me-2 text-primary"></i>Kwota oszczędności (PLN):
         </label>
         <div class="col-sm-8">
           <div class="d-flex align-items-center gap-2 flex-wrap">
-            <input type="number" class="form-control" id="savingsAmount" placeholder="np. 100000" value="100000" required>
+            <input type="number" class="form-control" id="savingsAmount" placeholder="np. 100000" value="100000" min="0" required>
             <input type="range" class="form-range flex-grow-1" id="savingsRange" min="0" max="500000" step="1000" value="100000">
           </div>
         </div>
@@ -57,7 +58,7 @@
           <i class="fas fa-percent me-2 text-primary"></i>Podatek od zysków (%):
         </label>
         <div class="col-sm-8">
-          <input type="number" class="form-control" id="taxRate" value="19" step="0.1" required>
+          <input type="number" class="form-control" id="taxRate" value="19" step="0.1" min="0" required>
         </div>
       </div>
       <div class="mb-4 row">
@@ -65,7 +66,7 @@
           <i class="fas fa-money-bill-wave me-2 text-primary"></i>Koszt pozyskania/utrzymania pozycji (PLN/mies.):
         </label>
         <div class="col-sm-8">
-          <input type="number" class="form-control" id="positionCost" value="0" step="0.01" min="-1000000" required>
+          <input type="number" class="form-control" id="positionCost" value="0" step="0.01" min="0" required>
         </div>
       </div>
 
@@ -75,7 +76,7 @@
         </label>
         <div class="col-sm-8">
           <div class="d-flex align-items-center gap-2 flex-wrap">
-            <input type="number" class="form-control" id="lockPeriod" value="365" required>
+            <input type="number" class="form-control" id="lockPeriod" value="365" min="0" required>
             <input type="range" class="form-range flex-grow-1" id="lockRange" min="0" max="365" step="1">
           </div>
         </div>
@@ -110,46 +111,46 @@
                 <tr>
                   <td class="fw-medium">Standard</td>
                   <td>
-                    <input type="number" class="form-control" id="costStandard" value="0" step="0.01">
+                    <input type="number" class="form-control" id="costStandard" value="0" step="0.01" min="0">
                   </td>
                   <td>
-                    <input type="number" class="form-control rate-cell" id="rateStandard" value="3.00" step="0.01">
+                    <input type="number" class="form-control rate-cell" id="rateStandard" value="3.00" step="0.01" min="0">
                   </td>
                 </tr>
                 <tr>
                   <td class="fw-medium">Plus (19,99)</td>
                   <td>
-                    <input type="number" class="form-control" id="costPlus" value="19.99" step="0.01">
+                    <input type="number" class="form-control" id="costPlus" value="19.99" step="0.01" min="0">
                   </td>
                   <td>
-                    <input type="number" class="form-control rate-cell" id="ratePlus" value="3.25" step="0.01">
+                    <input type="number" class="form-control rate-cell" id="ratePlus" value="3.25" step="0.01" min="0">
                   </td>
                 </tr>
                 <tr>
                   <td class="fw-medium">Premium (33,33)</td>
                   <td>
-                    <input type="number" class="form-control" id="costPremium" value="33.33" step="0.01">
+                    <input type="number" class="form-control" id="costPremium" value="33.33" step="0.01" min="0">
                   </td>
                   <td>
-                    <input type="number" class="form-control rate-cell" id="ratePremium" value="4.00" step="0.01">
+                    <input type="number" class="form-control rate-cell" id="ratePremium" value="4.00" step="0.01" min="0">
                   </td>
                 </tr>
                 <tr>
                   <td class="fw-medium">Metal (55,99)</td>
                   <td>
-                    <input type="number" class="form-control" id="costMetal" value="55.99" step="0.01">
+                    <input type="number" class="form-control" id="costMetal" value="55.99" step="0.01" min="0">
                   </td>
                   <td>
-                    <input type="number" class="form-control rate-cell" id="rateMetal" value="4.50" step="0.01">
+                    <input type="number" class="form-control rate-cell" id="rateMetal" value="4.50" step="0.01" min="0">
                   </td>
                 </tr>
                 <tr>
                   <td class="fw-medium">Ultra (210)</td>
                   <td>
-                    <input type="number" class="form-control" id="costUltra" value="210.00" step="0.01">
+                    <input type="number" class="form-control" id="costUltra" value="210.00" step="0.01" min="0">
                   </td>
                   <td>
-                    <input type="number" class="form-control rate-cell" id="rateUltra" value="5.00" step="0.01">
+                    <input type="number" class="form-control rate-cell" id="rateUltra" value="5.00" step="0.01" min="0">
                   </td>
                 </tr>
               </tbody>
@@ -184,7 +185,7 @@
           <label for="savingsAmountModify" class="col-sm-4 col-form-label" data-i18n="savingsLabelMod">Kwota oszczędności (PLN):</label>
           <div class="col-sm-8">
             <div class="d-flex align-items-center gap-2 flex-wrap">
-              <input type="number" class="form-control" id="savingsAmountModify" placeholder="np. 100000" value="100000">
+              <input type="number" class="form-control" id="savingsAmountModify" placeholder="np. 100000" value="100000" min="0">
               <input type="range" class="form-range flex-grow-1" id="savingsModifyRange" min="0" max="500000" step="1000" value="100000">
             </div>
           </div>
@@ -192,13 +193,13 @@
         <div class="mb-3 row">
           <label for="taxRateModify" class="col-sm-4 col-form-label" data-i18n="taxRateLabelMod">Podatek od zysków (%):</label>
           <div class="col-sm-8">
-            <input type="number" class="form-control" id="taxRateModify" value="19" step="0.1">
+            <input type="number" class="form-control" id="taxRateModify" value="19" step="0.1" min="0">
           </div>
         </div>
         <div class="mb-3 row">
           <label for="positionCostModify" class="col-sm-4 col-form-label" data-i18n="positionCostLabelMod">Koszt pozyskania/utrzymania pozycji (PLN/mies.):</label>
           <div class="col-sm-8">
-          <input type="number" class="form-control" id="positionCostModify" value="0" step="0.01" min="-1000000">
+          <input type="number" class="form-control" id="positionCostModify" value="0" step="0.01" min="0">
         </div>
       </div>
 
@@ -206,7 +207,7 @@
         <label for="lockPeriodModify" class="col-sm-4 col-form-label" data-i18n="lockPeriodLabelMod">Czas lokaty (dni):</label>
         <div class="col-sm-8">
           <div class="d-flex align-items-center gap-2 flex-wrap">
-            <input type="number" class="form-control" id="lockPeriodModify" value="365">
+            <input type="number" class="form-control" id="lockPeriodModify" value="365" min="0">
             <input type="range" class="form-range flex-grow-1" id="lockModifyRange" min="0" max="365" step="1">
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -38,7 +38,8 @@ const translations = {
     chartLabel: 'Zysk końcowy (PLN)',
     interestRate: 'Oprocentowanie',
     bestPlan: (plan, profit) => `<i class="fas fa-trophy me-2"></i>Najlepszy plan: <strong>${plan}</strong> (Zysk końcowy: <strong>${profit} PLN</strong>)`,
-    allLosses: (plan, loss) => `<i class="fas fa-exclamation-triangle me-2"></i>Uwaga: Wszystkie plany generują straty. Najlepsza opcja: <strong>${plan}</strong> (Strata: <strong>${loss} PLN</strong>)`
+    allLosses: (plan, loss) => `<i class="fas fa-exclamation-triangle me-2"></i>Uwaga: Wszystkie plany generują straty. Najlepsza opcja: <strong>${plan}</strong> (Strata: <strong>${loss} PLN</strong>)`,
+    invalidInput: 'Proszę wprowadzić poprawne liczby.'
   },
   en: {
     pageTitle: 'Savings Profit Simulation | Revolut',
@@ -77,7 +78,8 @@ const translations = {
     chartLabel: 'Final profit (PLN)',
     interestRate: 'Interest rate',
     bestPlan: (plan, profit) => `<i class="fas fa-trophy me-2"></i>Best plan: <strong>${plan}</strong> (Final profit: <strong>${profit} PLN</strong>)`,
-    allLosses: (plan, loss) => `<i class="fas fa-exclamation-triangle me-2"></i>Warning: All plans yield losses. Best option: <strong>${plan}</strong> (Loss: <strong>${loss} PLN</strong>)`
+    allLosses: (plan, loss) => `<i class="fas fa-exclamation-triangle me-2"></i>Warning: All plans yield losses. Best option: <strong>${plan}</strong> (Loss: <strong>${loss} PLN</strong>)`,
+    invalidInput: 'Please enter valid numbers.'
   }
 };
 
@@ -197,12 +199,56 @@ function updateGrossHeader() {
 }
 
 function calculateResults() {
+  // Hide previous error message
+  const errorEl = document.getElementById('inputError');
+  if (errorEl) errorEl.classList.add('d-none');
+
   // Pobierz dane wejściowe
-  const savings = parseFloat(document.getElementById('savingsAmount').value);
-  const taxRate = parseFloat(document.getElementById('taxRate').value);
-  let positionCost = parseFloat(document.getElementById('positionCost').value);
-  if (isNaN(positionCost)) positionCost = 0; // allow temporarily blank/"-" input
-  const lockPeriod = parseFloat(document.getElementById('lockPeriod').value);
+  const savingsInput = document.getElementById('savingsAmount');
+  const taxRateInput = document.getElementById('taxRate');
+  const positionCostInput = document.getElementById('positionCost');
+  const lockPeriodInput = document.getElementById('lockPeriod');
+
+  let savings = parseFloat(savingsInput.value);
+  let taxRate = parseFloat(taxRateInput.value);
+  let positionCost = parseFloat(positionCostInput.value);
+  let lockPeriod = parseFloat(lockPeriodInput.value);
+
+  // Replace NaN with sensible defaults
+  if (isNaN(savings)) savings = 0;
+  if (isNaN(taxRate)) taxRate = 0;
+  if (isNaN(positionCost)) positionCost = 0; // allow temporarily blank "-" input
+  if (isNaN(lockPeriod)) lockPeriod = 0;
+
+  // Basic validation & user feedback
+  let invalid = false;
+  [savingsInput, taxRateInput, positionCostInput, lockPeriodInput].forEach(el => el.classList.remove('is-invalid'));
+  if (isNaN(parseFloat(savingsInput.value)) || savings < 0) {
+    savingsInput.classList.add('is-invalid');
+    invalid = true;
+  }
+  if (isNaN(parseFloat(taxRateInput.value)) || taxRate < 0) {
+    taxRateInput.classList.add('is-invalid');
+    invalid = true;
+  }
+  if (isNaN(parseFloat(positionCostInput.value)) || positionCost < 0) {
+    positionCostInput.classList.add('is-invalid');
+    invalid = true;
+  }
+  if (isNaN(parseFloat(lockPeriodInput.value)) || lockPeriod < 0) {
+    lockPeriodInput.classList.add('is-invalid');
+    invalid = true;
+  }
+
+  if (invalid) {
+    if (errorEl) {
+      errorEl.textContent = translations[currentLang].invalidInput;
+      errorEl.classList.remove('d-none');
+    }
+    hideLoadingIndicator();
+    return;
+  }
+
   const compound = document.getElementById('useCompoundInterest').checked;
 
   // Pobierz dane dla poszczególnych planów


### PR DESCRIPTION
## Summary
- validate numeric inputs and show user warnings
- allow only non-negative numbers in main and modify forms
- add translation entries for invalid input message

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686babf4a71083219c4315baf50b2647